### PR TITLE
Create note

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -219,6 +219,14 @@ app.whenReady().then(() => {
   });
 
   ipcMain.handle("createNote", (event, path) => {
+    // Check if there are any special paths
+    if (path.includes("../")){
+      return
+    }
+    if (path.includes("..\\")){
+      return
+    }
+
     fs.writeFileSync(path, "")
     return
   });

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -218,6 +218,11 @@ app.whenReady().then(() => {
     return fs.writeFileSync(path, text, "utf-8");
   });
 
+  ipcMain.handle("createNote", (event, path) => {
+    fs.writeFileSync(path, "")
+    return
+  });
+
   createWindow()
 
   app.on('activate', function () {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -6,5 +6,6 @@ contextBridge.exposeInMainWorld("api", {
   listFolders: (currentNotebook) => ipcRenderer.invoke("listFolders", currentNotebook),
   listFiles: (dir) => ipcRenderer.invoke("listFiles", dir),
   getFile: (path) => ipcRenderer.invoke("getFile", path),
-  saveFile: (path, text) => ipcRenderer.invoke("saveFile", path, text)
+  saveFile: (path, text) => ipcRenderer.invoke("saveFile", path, text),
+  createNote: (path) => ipcRenderer.invoke("createNote", path)
 });

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -55,9 +55,34 @@
             <img src="./assets/material_symbols/markdown_white.svg" alt="Markdown" class="opacity-80">
           </button>
 
-          <button class="mx-1.5 hover-light">
+          <button class="mx-1.5 hover-light" @click="openCreateNoteMenu = true">
             <img src="./assets/material_symbols/edit_square.svg" alt="Markdown" class="opacity-80">
           </button>
+          <Transition name="fade">
+            <div class="absolute w-screen h-screen left-0 top-0 bg-black opacity-30 z-20" v-if="this.openCreateNoteMenu" @click="this.openCreateNoteMenu = false"></div>
+          </Transition>
+          <Transition name="slide-up">
+            <div class="absolute py-1.5 mt-8 bg-[#262626] z-50 rounded-lg shadow-md border border-[#5f5f5f]" v-if="this.openCreateNoteMenu">
+              <button class="flex py-2 pr-7 px-3 hover:bg-[#353535] w-full duration-200" @click="createNote('md')">
+                <img src="./assets/material_symbols/markdown.svg">
+                <div class="flex flex-col justify-center text-white ml-1.5">
+                  Markdown
+                </div>
+              </button>
+              <button class="flex py-2 pr-7 px-3 hover:bg-[#353535] w-full duration-200" @click="createNote('txt')">
+                <img src="./assets/material_symbols/notes.svg">
+                <div class="flex flex-col justify-center text-white ml-1.5">
+                  Plaintext
+                </div>
+              </button>
+              <button class="flex py-2 pr-7 px-3 hover:bg-[#353535] w-full duration-200" @click="createNote('scrap')">
+                <img src="./assets/material_symbols/contract.svg">
+                <div class="flex flex-col justify-center text-white ml-1.5">
+                  Scrap
+                </div>
+              </button>
+            </div>
+          </Transition>
         </div>
       </div>
 
@@ -121,6 +146,7 @@ export default {
     return {
       // Menu opens
       openSwitchNotebookMenu: false,
+      openCreateNoteMenu: false,
 
       // Paths
       currentNotebook: "",
@@ -162,6 +188,8 @@ export default {
       // Reload files and folders
       this.getFolders()
       this.getFiles()
+
+      this.currentFile = undefined
     },
     switchFolder(i){
       this.currentFolder = i
@@ -206,6 +234,22 @@ export default {
     exitPreview(){
       this.MdPreview = false
       this.$refs.editor.exitPreview()
+    },
+    createNote(extension){
+      const path = `$untitled-${Math.random()
+        .toString(36)
+        .slice(-8)}.${extension}`;
+      
+      window.api.createNote(this.currentFolder + "\\" + path)
+        .then(result => {
+          this.getFiles()
+          this.openFile(this.currentFolder + "\\" + path)
+        })
+        .catch(error => {
+          console.log(error)
+        })
+      
+        this.openCreateNoteMenu = false;
     }
 }}
 </script>

--- a/src/renderer/src/components/inEditor.vue
+++ b/src/renderer/src/components/inEditor.vue
@@ -9,9 +9,9 @@
       placeholder="Note Name"
     />
   </div>
-  <textarea id="markdown-editor" v-if="path.replace(/^.*[\\/]/, '').match(/[^.]+$/s)[0] === 'md'" v-show="!previewMd"></textarea>
+  <textarea id="markdown-editor" v-if="path.replace(/^.*[\\/]/, '').match(/[^.]+$/s)[0] === 'md'" v-show="!previewMd" placeholder="Type here..."  v-focus></textarea>
   <div id="md-preview" v-html="parsedMd" v-show="isPreviewMd" class="mdcontent whitespace-pre-line flex flex-col"></div>
-  <textarea class="w-full h-full bg-transparent" v-if="path.replace(/^.*[\\/]/, '').match(/[^.]+$/s)[0] === 'txt'" style="outline: none !important; caret-color: white" @input="update(textarea)" v-model="textarea"></textarea>
+  <textarea class="w-full h-full bg-transparent" v-if="path.replace(/^.*[\\/]/, '').match(/[^.]+$/s)[0] === 'txt'" style="outline: none !important; caret-color: white" @input="update(textarea)" v-model="textarea" placeholder="Type here..." v-focus></textarea>
   <inScrap v-if="path.replace(/^.*[\\/]/, '').match(/[^.]+$/s)[0] === 'scrap'" :data="textarea" :key="textarea" @save="update" />
 </template>
 
@@ -21,7 +21,14 @@ import EasyMDE from "easymde";
 import marked from "marked/marked.min.js";
 import hljs from "highlight.js"
 
+const focus = {
+  mounted: (el) => el.focus()
+}
+
 export default {
+  directives: {
+    focus
+  },
   props: [
       "path",
       "text"
@@ -69,8 +76,9 @@ export default {
         toolbar: false,
         status: false,
         forceSync: true,
+        autofocus: true,
         initialValue: this.textarea,
-        
+        placeholder: "Type here...",
         shortcuts: {
           togglePreview: null,
           toggleFullScreen: null,
@@ -87,7 +95,11 @@ export default {
   mounted(){
     this.textarea = this.text
 
-    this.notetitle = this.path.replace(/^.*[\\/]/, '').split('.').slice(0, -1).join('.')
+    if (this.path.replace(/^.*[\\/]/, '').split('.').slice(0, -1).join('.').startsWith('$untitled-')){
+      this.notetitle = ""
+    }else{
+      this.notetitle = this.path.replace(/^.*[\\/]/, '').split('.').slice(0, -1).join('.')
+    }
 
     this.easyMDE = undefined;
     const elements = document.querySelectorAll(".EasyMDEContainer");
@@ -105,7 +117,8 @@ export default {
         status: false,
         forceSync: true,
         initialValue: this.textarea,
-        
+        autofocus: true,
+        placeholder: "Type here...",
         shortcuts: {
           togglePreview: null,
           toggleFullScreen: null,
@@ -119,6 +132,8 @@ export default {
         this.textarea = this.easyMDE.value();
       });
     }
+
+    
   }
 }
 </script>

--- a/src/renderer/src/components/inNote.vue
+++ b/src/renderer/src/components/inNote.vue
@@ -6,7 +6,10 @@
     <img src="../assets/material_symbols/image.svg" alt="Scrap: " v-else-if="type === 'png'">
     <img src="../assets/material_symbols/unknown_document.svg" alt="Scrap: " v-else>
     <div>
-      <div class="text-white ml-2.5 text-[1.035rem] text-left">
+      <div class="text-white ml-2.5 text-[1.035rem] text-left" v-if="name.startsWith('$untitled-')">
+        New Note...
+      </div>
+      <div class="text-white ml-2.5 text-[1.035rem] text-left" v-else>
         {{ name }}
       </div>
     </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - IPCハンドラー「createNote」を追加し、指定されたパスに空の文字列を書き込む機能を実装しました。
    - メニューを介して異なる種類のノート（Markdown、Plaintext、Scrap）を作成できるようにしました。それぞれに対応するアイコンとアクションがあります。
    - メニューの表示と非表示にトランジションを追加しました。
    - 選択した拡張子に基づいてランダムなパスで新しいノートを作成する機能を実装しました。
- **機能改善**
    - ファイル拡張子に応じて`textarea`要素に`placeholder="Type here..."`と`v-focus`ディレクティブを追加しました。
    - 要素のフォーカスを扱うための`focus`ディレクティブを導入しました。
    - EasyMDEエディタの初期化時に`autofocus: true`と`placeholder: "Type here..."`を設定しました。
    - ファイルパスに基づいて`this.notetitle`の割り当てを調整しました。
    - `name`プロパティに基づいて、条件に応じて表示を切り替える機能を`inNote.vue`コンポーネントに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->