### PR TITLE
Rename notes

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -231,6 +231,11 @@ app.whenReady().then(() => {
     return
   });
 
+  ipcMain.handle("changeNoteTitle", (event, from, to) => {
+    fs.renameSync(from, path.join(path.dirname(from), to));
+    return path.join(path.dirname(from), to);
+  });
+
   createWindow()
 
   app.on('activate', function () {

--- a/src/preload/index.js
+++ b/src/preload/index.js
@@ -7,5 +7,6 @@ contextBridge.exposeInMainWorld("api", {
   listFiles: (dir) => ipcRenderer.invoke("listFiles", dir),
   getFile: (path) => ipcRenderer.invoke("getFile", path),
   saveFile: (path, text) => ipcRenderer.invoke("saveFile", path, text),
-  createNote: (path) => ipcRenderer.invoke("createNote", path)
+  createNote: (path) => ipcRenderer.invoke("createNote", path),
+  changeNoteTitle: (from, to) => ipcRenderer.invoke("changeNoteTitle", from, to)
 });

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -121,7 +121,7 @@
       </div>
       <div class="flex justify-center h-[calc(100%-52px)] overflow-hidden">
         <div class="w-full max-w-[45rem] mx-[2rem] mt-6 h-[calc(100%-24px)] border-none focus:outline-0 text-white">
-          <inEditor v-if="currentFile" :path="currentFile" :text="currentFileData" :key="currentFile" @save="saveFile" ref="editor" />
+          <inEditor v-if="currentFile" :path="currentFile" :text="currentFileData" :key="currentFile" @save="saveFile" @changeNoteTitle="changeNoteTitle" ref="editor" />
         </div>
       </div>
     </div>
@@ -250,6 +250,15 @@ export default {
         })
       
         this.openCreateNoteMenu = false;
+    },
+    changeNoteTitle(notetitle) {
+      document.activeElement.blur();
+
+      window.api.changeNoteTitle(this.currentFile, notetitle + "." + this.currentFile.replace(/^.*[\\/]/, '').match(/[^.]+$/s)[0])
+        .then((res) => {
+          this.getFiles();
+          this.openFile(res)
+        });
     }
 }}
 </script>

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -259,6 +259,9 @@ export default {
           this.getFiles();
           this.openFile(res)
         });
+        .catch(error => {
+          console.log(error)
+        })
     }
 }}
 </script>

--- a/src/renderer/src/components/inEditor.vue
+++ b/src/renderer/src/components/inEditor.vue
@@ -36,7 +36,7 @@ export default {
   components: {
     inScrap
   },
-  emits: ['save'],
+  emits: ['save', 'changeNoteTitle'],
   data: () => {
     return {
       notetitle: "",
@@ -90,7 +90,10 @@ export default {
         this.$emit("save", this.easyMDE.value());
         this.textarea = this.easyMDE.value()
       });
-    }
+    },
+    changeNoteTitle() {
+      this.$emit("changeNoteTitle", this.notetitle);
+    },
   },
   mounted(){
     this.textarea = this.text


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新機能**
    - ノートのタイトルを変更する機能を追加しました。`changeNoteTitle` IPC ハンドラは、古いタイトルから新しいタイトルにノートファイルの名前を変更し、更新されたファイルパスを返します。
    - `App.vue` コンポーネントに、ノートのタイトル変更を処理するための新しいメソッド `changeNoteTitle` が追加されました。API とやり取りし、ファイルデータを更新、エラーハンドリングを行います。
    - `inEditor.vue` コンポーネントでは、`emits` プロパティが `'changeNoteTitle'` を含むように更新されました。さらに、`changeNoteTitle` という新しいメソッドが追加され、`notetitle` の値とともにイベント `'changeNoteTitle'` を送出します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->